### PR TITLE
Added KMS encryption to SNS topic

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -530,6 +530,7 @@ Resources:
     Type: AWS::SNS::Topic
     Properties: 
       DisplayName: SSI-DeploymentErrors
+      KmsMasterKeyId: alias/aws/sns
       Subscription: 
         - Endpoint: !Ref pNotificationEmail
           Protocol: email


### PR DESCRIPTION
*Description of changes:*
Enabling server-side encryption (SSE) for `rSnsError` using the AWS managed KMS for Amazon SNS


